### PR TITLE
Agent posts are moving to lambdamechanic.com

### DIFF
--- a/_posts/2026-02-09-agent-posts-moving-to-lambdamechanic.md
+++ b/_posts/2026-02-09-agent-posts-moving-to-lambdamechanic.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "Agent posts are moving to lambdamechanic.com"
+description: ""
+category:
+tags: [agents, llm, mcp]
+---
+
+I’m going to be moving my technical blogging about agents to [lambdamechanic.com/blog](https://lambdamechanic.com/blog).
+
+If you want to follow along, there’s an RSS/Atom feed here:
+
+[https://lambdamechanic.com/feed.xml](https://lambdamechanic.com/feed.xml)
+
+I’ll be writing posts on agentic techniques, and the first one is up now: **Tooltest**, my new MCP fuzzing tool:
+
+[Tooltest: a fuzz-checker for your MCPs](https://lambdamechanic.com/blog/tooltest-a-fuzz-checker-for-your-mcps/)


### PR DESCRIPTION
This post announces that my technical blogging about agents is moving to lambdamechanic.com/blog, with a feed at https://lambdamechanic.com/feed.xml, and links to the first post on Tooltest (an MCP fuzzing tool).